### PR TITLE
Added `OrderedFields`.

### DIFF
--- a/mapping/structfield_test.go
+++ b/mapping/structfield_test.go
@@ -1,0 +1,77 @@
+package mapping
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrderedFields tests the ordered fields methods.
+func TestOrderedFields(t *testing.T) {
+	type Model struct {
+		ID     int
+		Name   string
+		First  string
+		Second int
+		Third  string
+	}
+	mm := testingModelMap(t)
+
+	err := mm.RegisterModels(Model{})
+	require.NoError(t, err)
+
+	m, err := mm.GetModelStruct(Model{})
+	require.NoError(t, err)
+
+	fields := m.Fields()
+
+	// unsort the slice
+	fields[0], fields[3], fields[2], fields[4] = fields[3], fields[0], fields[4], fields[2]
+
+	// Remove the 'Name' field at index [1]
+	fields = append(fields[:1], fields[2:]...)
+
+	ordered := OrderedFields(fields)
+	// sort the fields
+	sort.Sort(ordered)
+
+	for i, field := range ordered {
+		switch i {
+		case 0:
+			assert.Equal(t, "ID", field.Name())
+		case 1:
+			assert.Equal(t, "First", field.Name())
+		case 2:
+			assert.Equal(t, "Second", field.Name())
+		case 3:
+			assert.Equal(t, "Third", field.Name())
+		}
+	}
+
+	// insert back the name field
+	nameField, ok := m.Attribute("Name")
+	require.True(t, ok)
+
+	orderedPtr := &ordered
+	orderedPtr.Insert(nameField)
+
+	assert.Len(t, ordered, 5)
+
+	for i, field := range ordered {
+		switch i {
+		case 0:
+			assert.Equal(t, "ID", field.Name())
+		case 1:
+			assert.Equal(t, "Name", field.Name())
+		case 2:
+			assert.Equal(t, "First", field.Name())
+		case 3:
+			assert.Equal(t, "Second", field.Name())
+		case 4:
+			assert.Equal(t, "Third", field.Name())
+		}
+	}
+
+}

--- a/query/scope-fieldset.go
+++ b/query/scope-fieldset.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"reflect"
+	"sort"
 
 	"github.com/neuronlabs/errors"
 
@@ -9,6 +10,18 @@ import (
 	"github.com/neuronlabs/neuron-core/log"
 	"github.com/neuronlabs/neuron-core/mapping"
 )
+
+// OrderedFieldset gets the fieldset fields sorted by the struct field's index.
+func (s *Scope) OrderedFieldset() (ordered mapping.OrderedFields) {
+	var i int
+	ordered = mapping.OrderedFields(make([]*mapping.StructField, len(s.Fieldset)))
+	for _, field := range s.Fieldset {
+		ordered[i] = field
+		i++
+	}
+	sort.Sort(ordered)
+	return ordered
+}
 
 // InFieldset checks if the provided field is in the scope's fieldset.
 func (s *Scope) InFieldset(field interface{}) (*mapping.StructField, bool) {

--- a/query/scope-fieldset_test.go
+++ b/query/scope-fieldset_test.go
@@ -45,7 +45,8 @@ func TestOrderedFielset(t *testing.T) {
 		s, err := NewC(c, &Ordered{})
 		require.NoError(t, err)
 
-		s.SetFields("first", "id", "third")
+		err = s.SetFields("first", "id", "third")
+		require.NoError(t, err)
 
 		ordered := s.OrderedFieldset()
 		for i, field := range ordered {

--- a/query/scope-fieldset_test.go
+++ b/query/scope-fieldset_test.go
@@ -1,0 +1,62 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrderedFielset test the ordered fieldset function.
+func TestOrderedFielset(t *testing.T) {
+	type Ordered struct {
+		ID     int
+		First  string
+		Second string
+		Third  string
+	}
+
+	c := newController(t)
+	err := c.RegisterModels(Ordered{})
+	require.NoError(t, err)
+
+	t.Run("All", func(t *testing.T) {
+		s, err := NewC(c, &Ordered{})
+		require.NoError(t, err)
+
+		s.setAllFields()
+
+		ordered := s.OrderedFieldset()
+		for i, field := range ordered {
+			switch i {
+			case 0:
+				assert.Equal(t, "ID", field.Name())
+			case 1:
+				assert.Equal(t, "First", field.Name())
+			case 2:
+				assert.Equal(t, "Second", field.Name())
+			case 3:
+				assert.Equal(t, "Third", field.Name())
+			}
+		}
+	})
+
+	t.Run("Custom", func(t *testing.T) {
+		s, err := NewC(c, &Ordered{})
+		require.NoError(t, err)
+
+		s.SetFields("first", "id", "third")
+
+		ordered := s.OrderedFieldset()
+		for i, field := range ordered {
+			switch i {
+			case 0:
+				assert.Equal(t, "ID", field.Name())
+			case 1:
+				assert.Equal(t, "First", field.Name())
+			case 2:
+				assert.Equal(t, "Third", field.Name())
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR adds the `OrderedFields` wrapper over `[]*mapping.StructFields`.
This allows to sort and insert the slice elements by the index of the fields.

- Added `OrderedFields` wrapper to the `mapping` package.
- Added `OrderedFieldset`  method to the `query.Scope`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neuronlabs/neuron-core/36)
<!-- Reviewable:end -->
